### PR TITLE
CHAP02 data: Fix typo

### DIFF
--- a/CHAP02/data/main.tf
+++ b/CHAP02/data/main.tf
@@ -14,10 +14,10 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
@@ -28,20 +28,20 @@ data "azurerm_app_service_plan" "myplan" {
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = data.azurerm_app_service_plan.myplan.id
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "web"
 
   tags = {
-    ENV = var.environement
+    ENV = var.environment
     CreatedBy = var.createdby
   }
 }

--- a/CHAP02/data/terraform.tfvars
+++ b/CHAP02/data/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name = "Plan-App"
-environement = "DEV1"
+environment = "DEV1"
 custom_app_settings = {
     APP = "1"
 }

--- a/CHAP02/data/variables.tf
+++ b/CHAP02/data/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP02/external/main.tf
+++ b/CHAP02/external/main.tf
@@ -7,7 +7,7 @@ variable "application_name" {
 }
 
 variable "environment_name" {
-  description = "The name of environement"
+  description = "The name of environment"
 }
 
 variable "country_code" {

--- a/CHAP02/fct/main.tf
+++ b/CHAP02/fct/main.tf
@@ -7,18 +7,18 @@ variable "app_name" {
   description = "Name of application"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 
 #resource "azurerm_resource_group" "rg-app" {
-#  name     = upper(format("RG-%s-%s",var.app_name,var.environement))
+#  name     = upper(format("RG-%s-%s",var.app_name,var.environment))
 #  location = "westeurope"
 #}
 
 #FOR CONDITION
 resource "azurerm_resource_group" "rg-app" {
-  name     = var.environement == "Production" ? upper(format("RG-%s", var.app_name)) : upper(format("RG-%s-%s", var.app_name, var.environement))
+  name     = var.environment == "Production" ? upper(format("RG-%s", var.app_name)) : upper(format("RG-%s-%s", var.app_name, var.environment))
   location = "westeurope"
 }

--- a/CHAP02/fct/terraform.tfvars
+++ b/CHAP02/fct/terraform.tfvars
@@ -1,2 +1,2 @@
-environement = "Production"
+environment = "Production"
 app_name     = "myapp"

--- a/CHAP02/localvariables/main.tf
+++ b/CHAP02/localvariables/main.tf
@@ -7,7 +7,7 @@ variable "application_name" {
 }
 
 variable "environment_name" {
-  description = "The name of environement"
+  description = "The name of environment"
 }
 
 variable "country_code" {

--- a/CHAP02/myApp/simple-env/main.tf
+++ b/CHAP02/myApp/simple-env/main.tf
@@ -14,15 +14,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -32,26 +32,26 @@ resource "azurerm_app_service_plan" "plan-app" {
   }
 
   tags = {
-    ENV = var.environement
+    ENV = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "web"
 
   tags = {
-    ENV = var.environement
+    ENV = var.environment
     CreatedBy = var.createdby
   }
 }

--- a/CHAP02/myApp/simple-env/terraform.tfvars
+++ b/CHAP02/myApp/simple-env/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name = "Plan-App"
-environement = "DEV1"
+environment = "DEV1"
 custom_app_settings = {
     APP = "1"
 }

--- a/CHAP02/myApp/simple-env/variables.tf
+++ b/CHAP02/myApp/simple-env/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP02/myApp/solution1/dev/main.tf
+++ b/CHAP02/myApp/solution1/dev/main.tf
@@ -14,15 +14,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -32,26 +32,26 @@ resource "azurerm_app_service_plan" "plan-app" {
   }
 
   tags = {
-    ENV = var.environement
+    ENV = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "web"
 
   tags = {
-    ENV = var.environement
+    ENV = var.environment
     CreatedBy = var.createdby
   }
 }

--- a/CHAP02/myApp/solution1/dev/terraform.tfvars
+++ b/CHAP02/myApp/solution1/dev/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name = "Plan-App"
-environement = "DEV1"
+environment = "DEV1"
 custom_app_settings = {
     APP = "1"
 }

--- a/CHAP02/myApp/solution1/dev/variables.tf
+++ b/CHAP02/myApp/solution1/dev/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP02/myApp/solution1/production/main.tf
+++ b/CHAP02/myApp/solution1/production/main.tf
@@ -14,15 +14,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -32,26 +32,26 @@ resource "azurerm_app_service_plan" "plan-app" {
   }
 
   tags = {
-    ENV = var.environement
+    ENV = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "Web"
 
   tags = {
-    ENV = var.environement
+    ENV = var.environment
     CreatedBy = var.createdby
   }
 }

--- a/CHAP02/myApp/solution1/production/terraform.tfvars
+++ b/CHAP02/myApp/solution1/production/terraform.tfvars
@@ -1,3 +1,3 @@
 resource_group_name = "RG-App"
 service_plan_name = "Plan-App"
-environement = "DEV"
+environment = "DEV"

--- a/CHAP02/myApp/solution1/production/variables.tf
+++ b/CHAP02/myApp/solution1/production/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP02/myApp/solution1/test/main.tf
+++ b/CHAP02/myApp/solution1/test/main.tf
@@ -14,15 +14,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -32,26 +32,26 @@ resource "azurerm_app_service_plan" "plan-app" {
   }
 
   tags = {
-    ENV = var.environement
+    ENV = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "Web"
 
   tags = {
-    ENV = var.environement
+    ENV = var.environment
     CreatedBy = var.createdby
   }
 }

--- a/CHAP02/myApp/solution1/test/terraform.tfvars
+++ b/CHAP02/myApp/solution1/test/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name = "Plan-App"
-environement = "DEV1"
+environment = "DEV1"
 custom_app_settings = {
     APP = "1"
 }

--- a/CHAP02/myApp/solution1/test/variables.tf
+++ b/CHAP02/myApp/solution1/test/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP02/myApp/solution2/dev/terraform.tfvars
+++ b/CHAP02/myApp/solution2/dev/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name = "Plan-App"
-environement = "DEV1"
+environment = "DEV1"
 custom_app_settings = {
     APP = "1"
 }

--- a/CHAP02/myApp/solution2/main.tf
+++ b/CHAP02/myApp/solution2/main.tf
@@ -14,15 +14,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -32,26 +32,26 @@ resource "azurerm_app_service_plan" "plan-app" {
   }
 
   tags = {
-    ENV = var.environement
+    ENV = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "web"
 
   tags = {
-    ENV = var.environement
+    ENV = var.environment
     CreatedBy = var.createdby
   }
 }

--- a/CHAP02/myApp/solution2/production/terraform.tfvars
+++ b/CHAP02/myApp/solution2/production/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name = "Plan-App"
-environement = "DEV1"
+environment = "DEV1"
 custom_app_settings = {
     APP = "1"
 }

--- a/CHAP02/myApp/solution2/test/terraform.tfvars
+++ b/CHAP02/myApp/solution2/test/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name = "Plan-App"
-environement = "DEV1"
+environment = "DEV1"
 custom_app_settings = {
     APP = "1"
 }

--- a/CHAP02/myApp/solution2/variables.tf
+++ b/CHAP02/myApp/solution2/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP02/output/main.tf
+++ b/CHAP02/output/main.tf
@@ -1,5 +1,5 @@
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id
@@ -11,7 +11,7 @@ resource "azurerm_app_service" "app" {
   }
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }

--- a/CHAP02/remote-state/main.tf
+++ b/CHAP02/remote-state/main.tf
@@ -14,10 +14,10 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
@@ -33,20 +33,20 @@ data "terraform_remote_state" "service_plan_tfstate" {
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = data.terraform_remote_state.service_plan_tfstate.service_plan_id
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "Web"
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }

--- a/CHAP02/remote-state/terraform.tfvars
+++ b/CHAP02/remote-state/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name = "Plan-App"
-environement = "DEV1"
+environment = "DEV1"
 custom_app_settings = {
     APP = "1"
 }

--- a/CHAP02/remote-state/variables.tf
+++ b/CHAP02/remote-state/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP02/sample-app/main.tf
+++ b/CHAP02/sample-app/main.tf
@@ -14,15 +14,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -32,26 +32,26 @@ resource "azurerm_app_service_plan" "plan-app" {
   }
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "web"
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }

--- a/CHAP02/sample-app/terraform.tfvars
+++ b/CHAP02/sample-app/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App-demo"
 service_plan_name    = "Plan-App-demo"
-environement         = "DEV1"
+environment         = "DEV1"
 custom_app_settings = {
   APP = "1"
 }

--- a/CHAP02/sample-app/variables.tf
+++ b/CHAP02/sample-app/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp-demo"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP03/count/main.tf
+++ b/CHAP03/count/main.tf
@@ -8,15 +8,15 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -29,7 +29,7 @@ resource "azurerm_app_service_plan" "plan-app" {
 
 resource "azurerm_app_service" "app" {
   count               = var.nb_webapp
-  name                = "${var.app_name}-${var.environement}-${count.index+1}"
+  name                = "${var.app_name}-${var.environment}-${count.index+1}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id

--- a/CHAP03/count/terraform.tfvars
+++ b/CHAP03/count/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name = "Plan-App"
-environement = "DEV1"
+environment = "DEV1"
 
 
 nb_webapp = 2

--- a/CHAP03/count/variables.tf
+++ b/CHAP03/count/variables.tf
@@ -17,8 +17,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP03/list_map/main.tf
+++ b/CHAP03/list_map/main.tf
@@ -8,15 +8,15 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 

--- a/CHAP03/list_map/terraform.tfvars
+++ b/CHAP03/list_map/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name    = "Plan-App"
-environement         = "DEV1"
+environment         = "DEV1"
 
 
 web_apps = {

--- a/CHAP03/list_map/variables.tf
+++ b/CHAP03/list_map/variables.tf
@@ -17,8 +17,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP03/map/main.tf
+++ b/CHAP03/map/main.tf
@@ -8,14 +8,14 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
 
   tags = var.tags
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -26,7 +26,7 @@ resource "azurerm_app_service_plan" "plan-app" {
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id

--- a/CHAP03/map/terraform.tfvars
+++ b/CHAP03/map/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name    = "Plan-App"
-environement         = "DEV1"
+environment         = "DEV1"
 custom_app_settings = {
   APP = "1"
 }

--- a/CHAP03/map/variables.tf
+++ b/CHAP03/map/variables.tf
@@ -20,8 +20,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP03/map_merge/main.tf
+++ b/CHAP03/map_merge/main.tf
@@ -8,11 +8,11 @@ provider "azurerm" {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   ## OLD CODE WIThOUT MAP
   #tags = {
-  #  ENV = var.environement
+  #  ENV = var.environment
   #  CREATEDBY = var.created_by
   #}
 
@@ -20,7 +20,7 @@ resource "azurerm_resource_group" "rg-app" {
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -37,7 +37,7 @@ locals {
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id

--- a/CHAP03/map_merge/terraform.tfvars
+++ b/CHAP03/map_merge/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name    = "Plan-App"
-environement         = "DEV1"
+environment         = "DEV1"
 
 
 nb_webapp = 2

--- a/CHAP03/map_merge/variables.tf
+++ b/CHAP03/map_merge/variables.tf
@@ -20,8 +20,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 variable "createdby" {

--- a/CHAP04/sample-app/main.tf
+++ b/CHAP04/sample-app/main.tf
@@ -14,15 +14,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -32,26 +32,26 @@ resource "azurerm_app_service_plan" "plan-app" {
   }
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "web"
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }

--- a/CHAP04/sample-app/terraform.tfvars
+++ b/CHAP04/sample-app/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name    = "Plan-App"
-environement         = "DEV1"
+environment         = "DEV1"
 custom_app_settings = {
   APP = "1"
 }

--- a/CHAP04/sample-app/variables.tf
+++ b/CHAP04/sample-app/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP05/sample-app/main.tf
+++ b/CHAP05/sample-app/main.tf
@@ -14,15 +14,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -32,26 +32,26 @@ resource "azurerm_app_service_plan" "plan-app" {
   }
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "web"
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }

--- a/CHAP05/sample-app/terraform.tfvars
+++ b/CHAP05/sample-app/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name    = "Plan-App"
-environement         = "DEV1"
+environment         = "DEV1"
 custom_app_settings = {
   APP = "1"
 }

--- a/CHAP05/sample-app/variables.tf
+++ b/CHAP05/sample-app/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP06/keyvault/terraform.tfvars
+++ b/CHAP06/keyvault/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name    = "Plan-App"
-environement         = "DEV1"
+environment         = "DEV1"
 custom_app_settings = {
   APP = "1"
 }

--- a/CHAP06/keyvault/variables.tf
+++ b/CHAP06/keyvault/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP06/sample-app/main.tf
+++ b/CHAP06/sample-app/main.tf
@@ -14,15 +14,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -32,26 +32,26 @@ resource "azurerm_app_service_plan" "plan-app" {
   }
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "web"
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }

--- a/CHAP06/sample-app/terraform.tfvars
+++ b/CHAP06/sample-app/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name    = "Plan-App"
-environement         = "DEV1"
+environment         = "DEV1"
 custom_app_settings = {
   APP = "1"
 }

--- a/CHAP06/sample-app/variables.tf
+++ b/CHAP06/sample-app/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP06/webapp/main.tf
+++ b/CHAP06/webapp/main.tf
@@ -14,15 +14,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -32,19 +32,19 @@ resource "azurerm_app_service_plan" "plan-app" {
   }
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "web"
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }
@@ -83,7 +83,7 @@ data "azurerm_storage_account_sas" "storage_sas" {
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id

--- a/CHAP06/webapp/terraform.tfvars
+++ b/CHAP06/webapp/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name    = "Plan-App"
-environement         = "DEV1"
+environment         = "DEV1"
 custom_app_settings = {
   APP = "1"
 }

--- a/CHAP06/webapp/variables.tf
+++ b/CHAP06/webapp/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP06/wrapper/dev/env-vars.tfvars
+++ b/CHAP06/wrapper/dev/env-vars.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App2"
 service_plan_name    = "Plan-App2"
-environement         = "DEVdemo"
+environment         = "DEVdemo"
 custom_app_settings = {
   APP = "1"
 }

--- a/CHAP06/wrapper/main.tf
+++ b/CHAP06/wrapper/main.tf
@@ -14,15 +14,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -32,13 +32,13 @@ resource "azurerm_app_service_plan" "plan-app" {
   }
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id
@@ -50,19 +50,19 @@ resource "azurerm_app_service" "app" {
   }
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "Web"
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
     Test      = "ok2"
   }

--- a/CHAP06/wrapper/prod/env-vars.tfvars
+++ b/CHAP06/wrapper/prod/env-vars.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App-Prod"
 service_plan_name    = "Plan-App"
-environement         = "PRODdemo"
+environment         = "PRODdemo"
 custom_app_settings = {
   APP = "2"
 }

--- a/CHAP06/wrapper/variables.tf
+++ b/CHAP06/wrapper/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP07/demogrunt-wrapper/env-vars.tfvars
+++ b/CHAP07/demogrunt-wrapper/env-vars.tfvars
@@ -1,7 +1,7 @@
 app_name             = "MyApp"
 resource_group_name = "RG-App"
 service_plan_name    = "Plan-App"
-environement         = "DEV1"
+environment         = "DEV1"
 custom_app_settings = {
   APP = "1"
 }

--- a/CHAP07/demogrunt-wrapper/main.tf
+++ b/CHAP07/demogrunt-wrapper/main.tf
@@ -15,15 +15,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -33,26 +33,26 @@ resource "azurerm_app_service_plan" "plan-app" {
   }
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "web"
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }

--- a/CHAP07/demogrunt-wrapper/variables.tf
+++ b/CHAP07/demogrunt-wrapper/variables.tf
@@ -15,8 +15,8 @@ variable "app_name" {
   description = "Name of application"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP07/preventdestroy/main.tf
+++ b/CHAP07/preventdestroy/main.tf
@@ -14,15 +14,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -32,26 +32,26 @@ resource "azurerm_app_service_plan" "plan-app" {
   }
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-test-${var.environement}"
+  name                = "${var.app_name}-test-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "web"
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 

--- a/CHAP07/preventdestroy/terraform.tfvars
+++ b/CHAP07/preventdestroy/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name    = "Plan-App"
-environement         = "DEV2"
+environment         = "DEV2"
 custom_app_settings = {
   APP = "1"
 }

--- a/CHAP07/preventdestroy/variables.tf
+++ b/CHAP07/preventdestroy/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp2"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP07/sample-app/main.tf
+++ b/CHAP07/sample-app/main.tf
@@ -14,15 +14,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -32,26 +32,26 @@ resource "azurerm_app_service_plan" "plan-app" {
   }
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}"
+  name                = "${var.app_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "web"
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }

--- a/CHAP07/sample-app/terraform.tfvars
+++ b/CHAP07/sample-app/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name    = "Plan-App"
-environement         = "DEV1"
+environment         = "DEV1"
 custom_app_settings = {
   APP = "1"
 }

--- a/CHAP07/sample-app/variables.tf
+++ b/CHAP07/sample-app/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyApp"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 

--- a/CHAP07/zerodowntime/main.tf
+++ b/CHAP07/zerodowntime/main.tf
@@ -14,15 +14,15 @@ locals {
 }
 
 resource "azurerm_resource_group" "rg-app" {
-  name     = "${var.resource_group_name}-${var.environement}"
+  name     = "${var.resource_group_name}-${var.environment}"
   location = var.location
   tags = {
-    ENV = var.environement
+    ENV = var.environment
   }
 }
 
 resource "azurerm_app_service_plan" "plan-app" {
-  name                = "${var.service_plan_name}-${var.environement}"
+  name                = "${var.service_plan_name}-${var.environment}"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
 
@@ -32,13 +32,13 @@ resource "azurerm_app_service_plan" "plan-app" {
   }
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }
 
 resource "azurerm_app_service" "app" {
-  name                = "${var.app_name}-${var.environement}-demo"
+  name                = "${var.app_name}-${var.environment}-demo"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   app_service_plan_id = azurerm_app_service_plan.plan-app.id
@@ -49,13 +49,13 @@ resource "azurerm_app_service" "app" {
 }
 
 resource "azurerm_application_insights" "appinsight-app" {
-  name                = "${var.app_name}-${var.environement}-demo"
+  name                = "${var.app_name}-${var.environment}-demo"
   location            = azurerm_resource_group.rg-app.location
   resource_group_name = azurerm_resource_group.rg-app.name
   application_type    = "web"
 
   tags = {
-    ENV       = var.environement
+    ENV       = var.environment
     CreatedBy = var.createdby
   }
 }

--- a/CHAP07/zerodowntime/terraform.tfvars
+++ b/CHAP07/zerodowntime/terraform.tfvars
@@ -1,6 +1,6 @@
 resource_group_name = "RG-App"
 service_plan_name    = "Plan-App"
-environement         = "DEV1"
+environment         = "DEV1"
 custom_app_settings = {
   APP = "1"
 }

--- a/CHAP07/zerodowntime/variables.tf
+++ b/CHAP07/zerodowntime/variables.tf
@@ -16,8 +16,8 @@ variable "app_name" {
   default     = "MyAppDemo"
 }
 
-variable "environement" {
-  description = "Environement Name"
+variable "environment" {
+  description = "Environment Name"
 }
 
 


### PR DESCRIPTION
This PR fixes a typo in Chapter 02. `environement` should be renamed to `environment`.